### PR TITLE
Remove 3 specific tests which duplicated by generic one

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "sdk.coverage.tests"]
 	path = sdk.coverage.tests
 	url = https://github.com/applitools/sdk.coverage.tests.git
-	branch = DotNet_POC
+	branch = DotNet_POC_test
 [submodule "Eyes.Ufg.DotNet"]
 	path = Eyes.Ufg.DotNet
 	url = https://github.com/applitools/Eyes.Ufg.DotNet.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "sdk.coverage.tests"]
 	path = sdk.coverage.tests
 	url = https://github.com/applitools/sdk.coverage.tests.git
-	branch = DotNet_POC_test
+	branch = DotNet_POC
 [submodule "Eyes.Ufg.DotNet"]
 	path = Eyes.Ufg.DotNet
 	url = https://github.com/applitools/Eyes.Ufg.DotNet.git

--- a/Tests/Test.Eyes.Selenium.DotNet/Resources/IncludedTests.txt
+++ b/Tests/Test.Eyes.Selenium.DotNet/Resources/IncludedTests.txt
@@ -11,7 +11,6 @@ Applitools.Selenium.Tests.TestClassicApi(Chrome, CSS).TestCheckFrame
 Applitools.Selenium.Tests.TestClassicApi(Chrome, CSS).TestCheckRegion
 Applitools.Selenium.Tests.TestClassicApi(Chrome, CSS).TestCheckRegion2
 Applitools.Selenium.Tests.TestClassicApi(Chrome, CSS).TestCheckRegionInFrame
-Applitools.Selenium.Tests.TestClassicApi(Chrome, CSS).TestCheckWindow
 Applitools.Selenium.Tests.TestClassicApi(Chrome, CSS).TestCheckWindowAfterScroll
 Applitools.Selenium.Tests.TestClassicApi(Chrome, CSS).TestCheckWindowFully
 Applitools.Selenium.Tests.TestClassicApi(Chrome, CSS).TestCheckWindowViewport
@@ -19,7 +18,6 @@ Applitools.Selenium.Tests.TestClassicApi(Chrome, CSS).TestDoubleCheckWindow
 Applitools.Selenium.Tests.TestClassicApi(Chrome, Scroll).TestCheckFrame
 Applitools.Selenium.Tests.TestClassicApi(Chrome, Scroll).TestCheckRegion
 Applitools.Selenium.Tests.TestClassicApi(Chrome, Scroll).TestCheckRegionInFrame
-Applitools.Selenium.Tests.TestClassicApi(Chrome, Scroll).TestCheckWindow
 Applitools.Selenium.Tests.TestClassicApi(Chrome, Scroll).TestCheckWindowAfterScroll
 Applitools.Selenium.Tests.TestClassicApi(Chrome, Scroll).TestCheckWindowFully
 Applitools.Selenium.Tests.TestClassicApi(Chrome, Scroll).TestCheckWindowViewport
@@ -29,7 +27,6 @@ Applitools.Selenium.Tests.TestClassicApi(Chrome, VG).TestCheckInnerFrame
 Applitools.Selenium.Tests.TestClassicApi(Chrome, VG).TestCheckRegion
 Applitools.Selenium.Tests.TestClassicApi(Chrome, VG).TestCheckRegion2
 Applitools.Selenium.Tests.TestClassicApi(Chrome, VG).TestCheckRegionInFrame
-Applitools.Selenium.Tests.TestClassicApi(Chrome, VG).TestCheckWindow
 Applitools.Selenium.Tests.TestClassicApi(Chrome, VG).TestCheckWindowAfterScroll
 Applitools.Selenium.Tests.TestClassicApi(Chrome, VG).TestCheckWindowFully
 Applitools.Selenium.Tests.TestClassicApi(Chrome, VG).TestCheckWindowViewport
@@ -379,12 +376,6 @@ Applitools.Selenium.Tests.TestSpecialCases(Chrome, CSS).TestCheckElementBiggerTh
 Applitools.Selenium.Tests.TestSpecialCases(Chrome, Scroll).TestCheckElementBiggerThanHTML
 Applitools.Selenium.Tests.TestDefaultRootElement.TestCheckDefaultElementBiggerBody
 Applitools.Selenium.Tests.VisualGridTests.TestVisualGridVisualViewport.TestUFGVisualViewport
-Applitools.Selenium.Tests.TestBigPages(Chrome, CSS).TestCheckCoreceLargeImage
-Applitools.Selenium.Tests.TestBigPages(Chrome, CSS).TestCheckCoreceLongImage
-Applitools.Selenium.Tests.TestBigPages(Chrome, Scroll).TestCheckCoreceLargeImage
-Applitools.Selenium.Tests.TestBigPages(Chrome, Scroll).TestCheckCoreceLongImage
-# Applitools.Selenium.Tests.TestBigPages(Chrome, VG).TestCheckCoreceLargeImage
-# Applitools.Selenium.Tests.TestBigPages(Chrome, VG).TestCheckCoreceLongImage
 Applitools.Selenium.Tests.TestSpecialCases(Chrome, Scroll).TestCheckElementFullyOnBottomAfterScroll
 Applitools.Selenium.Tests.TestSpecialCases(Chrome, CSS).TestCheckElementFullyOnBottomAfterScroll
 Applitools.Selenium.Tests.TestSpecialCases(Chrome, VG).TestCheckElementFullyOnBottomAfterScroll


### PR DESCRIPTION
Specific tests TestCheckWindow, TestCheckCoreceLargeImage, TestCheckCoreceLongImage were added to generic tests by commit https://github.com/applitools/sdk.coverage.tests/commit/4229c11f8fb37805e89d4db812c66f5ac1fef2d1  .
So these tests can be removed. 
Here is successful run of branch rfe_trello_specific_tests_to_generic with updates - https://travis-ci.com/github/applitools/Eyes.Sdk.DotNet/builds/195630593