### PR TITLE
Implement updated test coverage framework, add firefox driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "sdk.coverage.tests"]
 	path = sdk.coverage.tests
 	url = https://github.com/applitools/sdk.coverage.tests.git
-	branch = DotNet_POC
+	branch = DotNet_POC_test
 [submodule "Eyes.Ufg.DotNet"]
 	path = Eyes.Ufg.DotNet
 	url = https://github.com/applitools/Eyes.Ufg.DotNet.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "sdk.coverage.tests"]
 	path = sdk.coverage.tests
 	url = https://github.com/applitools/sdk.coverage.tests.git
-	branch = DotNet_POC_test
+	branch = DotNet_POC
 [submodule "Eyes.Ufg.DotNet"]
 	path = Eyes.Ufg.DotNet
 	url = https://github.com/applitools/Eyes.Ufg.DotNet.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,11 @@ script:
   - latestChromeDriverURL=$(wget http://chromedriver.storage.googleapis.com/LATEST_RELEASE -q -O -)
   - wget "http://chromedriver.storage.googleapis.com/${latestChromeDriverURL}/chromedriver_linux64.zip"
   - unzip chromedriver_linux64.zip -d /home/travis/build/
+  - wget -N https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz -P ~/
+  - tar -xzf ~/geckodriver-v0.26.0-linux64.tar.gz -C ~/
+  - rm ~/geckodriver-v0.26.0-linux64.tar.gz
+  - sudo mv -f ~/geckodriver /home/travis/build/
+  - sudo chmod +x /home/travis/build/geckodriver
   - export CHROME_BIN=chromium-browser
   - export DRIVER_PATH=/home/travis/build/
   - export APPLITOOLS_REPORT_ID=${TRAVIS_COMMIT:0:7}-$TRAVIS_BUILD_NUMBER

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ branches:
 
 addons:
   chrome: stable
+  firefox: latest
 
 git:
   depth: 3

--- a/Tests/Test.Eyes.Selenium.DotNet/Resources/IncludedTests.txt
+++ b/Tests/Test.Eyes.Selenium.DotNet/Resources/IncludedTests.txt
@@ -379,6 +379,12 @@ Applitools.Selenium.Tests.TestSpecialCases(Chrome, CSS).TestCheckElementBiggerTh
 Applitools.Selenium.Tests.TestSpecialCases(Chrome, Scroll).TestCheckElementBiggerThanHTML
 Applitools.Selenium.Tests.TestDefaultRootElement.TestCheckDefaultElementBiggerBody
 Applitools.Selenium.Tests.VisualGridTests.TestVisualGridVisualViewport.TestUFGVisualViewport
+Applitools.Selenium.Tests.TestBigPages(Chrome, CSS).TestCheckCoreceLargeImage
+Applitools.Selenium.Tests.TestBigPages(Chrome, CSS).TestCheckCoreceLongImage
+Applitools.Selenium.Tests.TestBigPages(Chrome, Scroll).TestCheckCoreceLargeImage
+Applitools.Selenium.Tests.TestBigPages(Chrome, Scroll).TestCheckCoreceLongImage
+# Applitools.Selenium.Tests.TestBigPages(Chrome, VG).TestCheckCoreceLargeImage
+# Applitools.Selenium.Tests.TestBigPages(Chrome, VG).TestCheckCoreceLongImage
 Applitools.Selenium.Tests.TestSpecialCases(Chrome, Scroll).TestCheckElementFullyOnBottomAfterScroll
 Applitools.Selenium.Tests.TestSpecialCases(Chrome, CSS).TestCheckElementFullyOnBottomAfterScroll
 Applitools.Selenium.Tests.TestSpecialCases(Chrome, VG).TestCheckElementFullyOnBottomAfterScroll


### PR DESCRIPTION
This PR can be merged only after this - https://github.com/applitools/sdk.coverage.tests/pull/12
After first PR is merged link to  DotNet_POC_test must be returned back to DotNet_POC and only after this the PR can be merged.
PR add geckodriver (for Firefox) because some tests in updated generic tests' list are performed at Firefox.
PR return to run several specific tests which were removed from run before. These tests are absent from updated generic tests' list now. When these tests are added to generic they will removed from specific run again