### PR TITLE
Set link to master branch instead of test branch

### DIFF
--- a/coverage-tests/configuration/index.js
+++ b/coverage-tests/configuration/index.js
@@ -1,8 +1,8 @@
 module.exports = {
   name: 'eyes_selenium_dotnet',
-  emitter: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/moveDotNetToMaster/DotNet/emitter.js',
-  overrides: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/moveDotNetToMaster/DotNet/overrides.js',
-  template: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/moveDotNetToMaster/DotNet/template.hbs',
+  emitter: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/master/DotNet/emitter.js',
+  overrides: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/master/DotNet/overrides.js',
+  template: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/master/DotNet/template.hbs',
   ext: '.cs',
   outPath: './test/Selenium/coverage/generic'
 }


### PR DESCRIPTION
In PR https://github.com/applitools/Eyes.Sdk.DotNet/pull/56  link to emitter, overrides, template was set to test branch for test run. Now it should be set to master branch