### PR TITLE
Switching run and reporting of generic tests under the control of the framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,15 +68,9 @@ before_script:
 jobs:
   include:
     - stage: Test
-      name: Generated Tests
+      name: Generic Tests
       script:
-        - echo "generating tests"
-        - pushd coverage-tests
-        - npm run dotnet:generate
-        - popd
-        - chmod +x ./buildProjects.sh
-        - ./buildProjects.sh coverage-tests/test/Appium/*.csproj
-        - ./buildProjects.sh coverage-tests/test/Selenium/*.csproj
+        - chmod +x ./genericTests.sh && ./genericTests.sh
 
     - name: Images
       script:

--- a/coverage-tests/package.json
+++ b/coverage-tests/package.json
@@ -14,19 +14,14 @@
     "url": "git+https://github.com/applitools/sdk.coverage.tests.git"
   },
   "scripts": {
-    "dotnet:generate": "npm install && coverage-tests generate ./configuration && mv ./test/Selenium/coverage/generic/*Native*.cs ./test/Appium/coverage/generic && mv ./test/Selenium/coverage/generic/Appium*.cs ./test/Appium/coverage/generic",
-    "dotnet:generate:local": "npm install && coverage-tests generate ./configuration --tests ./coverage-tests.js && mv ./test/Selenium/coverage/generic/*Native*.cs ./test/Appium/coverage/generic && mv ./test/Selenium/coverage/generic/Appium*.cs ./test/Appium/coverage/generic",
-    "dotnet:generate:win": "npm install && coverage-tests generate ./configuration && move /Y .\\test\\Selenium\\coverage\\generic\\*Native*.cs .\\test\\Appium\\coverage\\generic && move /Y .\\test\\Selenium\\coverage\\generic\\Appium*.cs .\\test\\Appium\\coverage\\generic",
-    "dotnet:generate:win:local": "coverage-tests generate ./configuration --tests ./coverage-tests.js && move /Y .\\test\\Selenium\\coverage\\generic\\*Native*.cs .\\test\\Appium\\coverage\\generic && move /Y .\\test\\Selenium\\coverage\\generic\\Appium*.cs .\\test\\Appium\\coverage\\generic",
-    "dotnet:run:parallel": "cd ./dotNet/test && APPLITOOLS_BATCH_ID=$(uuidgen) dotnet test --logger \"junit;LogFilePath=./../coverage-test-report.xml\"",
-    "dotnet:run:appium": "cd ./dotNet/test/Appium && APPLITOOLS_BATCH_ID=$(uuidgen) dotnet test --logger \"junit;LogFilePath=./../coverage-test-report.xml\"",
-    "dotnet:run:selenium": "cd ./dotNet/test/Selenium && APPLITOOLS_BATCH_ID=$(uuidgen) dotnet test --logger \"junit;LogFilePath=./../coverage-test-report.xml\"",
-    "dotnet:run:parallel:win": "cd ./dotNet/test && set APPLITOOLS_BATCH_ID=$(uuidgen) && dotnet test --logger \"junit;LogFilePath=./../coverage-test-report.xml\"",
-    "dotnet:run:appium:win": "cd ./dotNet/test/Appium && set APPLITOOLS_BATCH_ID=$(uuidgen) && dotnet test --logger \"junit;LogFilePath=./../coverage-test-report.xml\"",
-    "dotnet:run:selenium:win": "cd ./dotNet/test/Selenium && set APPLITOOLS_BATCH_ID=$(uuidgen) && dotnet test --logger \"junit;LogFilePath=./../coverage-test-report.xml\"",
+    "dotnet:generate": "npm install && coverage-tests generate ./configuration --pascalizeTests --strict && mv ./test/Selenium/coverage/generic/*Native*.cs ./test/Appium/coverage/generic && mv ./test/Selenium/coverage/generic/Appium*.cs ./test/Appium/coverage/generic",
+    "dotnet:generate:local": "npm install && coverage-tests generate ./configuration --pascalizeTests --strict --tests ./coverage-tests.js && mv ./test/Selenium/coverage/generic/*Native*.cs ./test/Appium/coverage/generic && mv ./test/Selenium/coverage/generic/Appium*.cs ./test/Appium/coverage/generic",
+    "dotnet:generate:win": "npm install && coverage-tests generate ./configuration --pascalizeTests --strict && move /Y .\\test\\Selenium\\coverage\\generic\\*Native*.cs .\\test\\Appium\\coverage\\generic && move /Y .\\test\\Selenium\\coverage\\generic\\Appium*.cs .\\test\\Appium\\coverage\\generic",
+    "dotnet:generate:win:local": "coverage-tests generate ./configuration --pascalizeTests --strict --tests ./coverage-tests.js && move /Y .\\test\\Selenium\\coverage\\generic\\*Native*.cs .\\test\\Appium\\coverage\\generic && move /Y .\\test\\Selenium\\coverage\\generic\\Appium*.cs .\\test\\Appium\\coverage\\generic",
+    "dotnet:run:parallel": "APPLITOOLS_BATCH_ID=$(uuidgen) dotnet test --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
     "dotnet:report": "[ \"$TEST_REPORT_SANDBOX\" = \"False\" ] && npm run dotnet:report:prod || npm run dotnet:report:sandbox ",
-    "dotnet:report:sandbox": "cd dotNet && coverage-tests process-report --path . --reportId $APPLITOOLS_REPORT_ID",
-    "dotnet:report:prod": "cd dotNet && coverage-tests process-report --path . --reportId $APPLITOOLS_REPORT_ID --send-report prod",
+    "dotnet:report:sandbox": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID",
+    "dotnet:report:prod": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID",
     "dotnet:tests": "./dotNet/dotnet_tests.sh"
   },
   "dependencies": {

--- a/coverage-tests/package.json
+++ b/coverage-tests/package.json
@@ -24,7 +24,7 @@
     "dotnet:report:merge": "junit-merge -d test -o coverage-test-report.xml",
     "dotnet:report": "[ \"$TEST_REPORT_SANDBOX\" = \"False\" ] && npm run dotnet:report:prod || npm run dotnet:report:sandbox ",
     "dotnet:report:sandboxOLD": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Appium",
-    "dotnet:report:sandbox": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID",
+    "dotnet:report:sandbox": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID && coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID",
     "dotnet:report:prodOLD": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium",
     "dotnet:report:prod": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID",
     "dotnet:tests": "./dotNet/dotnet_tests.sh"

--- a/coverage-tests/package.json
+++ b/coverage-tests/package.json
@@ -18,10 +18,11 @@
     "dotnet:generate:local": "npm install && coverage-tests generate ./configuration --pascalizeTests --strict --tests ./coverage-tests.js && mv ./test/Selenium/coverage/generic/*Native*.cs ./test/Appium/coverage/generic && mv ./test/Selenium/coverage/generic/Appium*.cs ./test/Appium/coverage/generic",
     "dotnet:generate:win": "npm install && coverage-tests generate ./configuration --pascalizeTests --strict && move /Y .\\test\\Selenium\\coverage\\generic\\*Native*.cs .\\test\\Appium\\coverage\\generic && move /Y .\\test\\Selenium\\coverage\\generic\\Appium*.cs .\\test\\Appium\\coverage\\generic",
     "dotnet:generate:win:local": "coverage-tests generate ./configuration --pascalizeTests --strict --tests ./coverage-tests.js && move /Y .\\test\\Selenium\\coverage\\generic\\*Native*.cs .\\test\\Appium\\coverage\\generic && move /Y .\\test\\Selenium\\coverage\\generic\\Appium*.cs .\\test\\Appium\\coverage\\generic",
-    "dotnet:run:parallel": "cd .. && APPLITOOLS_BATCH_ID=$(uuidgen) dotnet test -f netcoreapp3.1 Eyes.Sdk.DotNet_Travis.sln --filter Generated --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
+    "dotnet:run:parallelOld": "cd .. && dotnet test -f netcoreapp3.1 Eyes.Sdk.DotNet_Travis.sln --filter Generated --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
+	"dotnet:run:parallel": "dotnet test -f netcoreapp3.1 ./test/Selenium --logger \"junit;LogFilePath=./coverage-test-report.xml\" && dotnet test -f netcoreapp3.1 ./test/Appium --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
     "dotnet:report": "[ \"$TEST_REPORT_SANDBOX\" = \"False\" ] && npm run dotnet:report:prod || npm run dotnet:report:sandbox ",
-    "dotnet:report:sandbox": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID",
-    "dotnet:report:prod": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID",
+    "dotnet:report:sandbox": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Appium",
+    "dotnet:report:prod": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium",
     "dotnet:tests": "./dotNet/dotnet_tests.sh"
   },
   "dependencies": {

--- a/coverage-tests/package.json
+++ b/coverage-tests/package.json
@@ -19,14 +19,20 @@
     "dotnet:generate:win": "npm install && coverage-tests generate ./configuration --pascalizeTests --strict && move /Y .\\test\\Selenium\\coverage\\generic\\*Native*.cs .\\test\\Appium\\coverage\\generic && move /Y .\\test\\Selenium\\coverage\\generic\\Appium*.cs .\\test\\Appium\\coverage\\generic",
     "dotnet:generate:win:local": "coverage-tests generate ./configuration --pascalizeTests --strict --tests ./coverage-tests.js && move /Y .\\test\\Selenium\\coverage\\generic\\*Native*.cs .\\test\\Appium\\coverage\\generic && move /Y .\\test\\Selenium\\coverage\\generic\\Appium*.cs .\\test\\Appium\\coverage\\generic",
     "dotnet:run:parallelOld": "cd .. && dotnet test -f netcoreapp3.1 Eyes.Sdk.DotNet_Travis.sln --filter Generated --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
-    "dotnet:run:parallel": "dotnet test -f netcoreapp3.1 ./test/Selenium --logger \"junit;LogFilePath=./coverage-test-report.xml\" && dotnet test -f netcoreapp3.1 ./test/Appium --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
+    "dotnet:run:parallel:selenium": "dotnet test -f netcoreapp3.1 ./test/Selenium --logger \"junit;LogFilePath=./../coverage-test-reportS.xml\"",
+	"dotnet:run:parallel:appium": "dotnet test -f netcoreapp3.1 ./test/Appium --logger \"junit;LogFilePath=./../coverage-test-reportA.xml\"",
+    "dotnet:run:parallel22": "dotnet test -f netcoreapp3.1 ./test --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
+    "dotnet:report:merge": "junit-merge -d test -o coverage-test-report.xml",
     "dotnet:report": "[ \"$TEST_REPORT_SANDBOX\" = \"False\" ] && npm run dotnet:report:prod || npm run dotnet:report:sandbox ",
-    "dotnet:report:sandbox": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Appium",
-    "dotnet:report:prod": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium",
+    "dotnet:report:sandboxOLD": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Appium",
+    "dotnet:report:sandbox": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID && coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID",
+    "dotnet:report:prodOLD": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium",
+    "dotnet:report:prod": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID",
     "dotnet:tests": "./dotNet/dotnet_tests.sh"
   },
   "dependencies": {
     "@applitools/sdk-coverage-tests": "^2.3.7",
+    "junit-merge": "^2.0.0",
     "@typescript-eslint/parser": "^2.14.0",
     "typescript": "^3.7.4"
   },

--- a/coverage-tests/package.json
+++ b/coverage-tests/package.json
@@ -21,7 +21,7 @@
     "dotnet:run:parallelOld": "cd .. && dotnet test -f netcoreapp3.1 Eyes.Sdk.DotNet_Travis.sln --filter Generated --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
     "dotnet:run:parallel": "dotnet test -f netcoreapp3.1 ./test/Selenium --logger \"junit;LogFilePath=./coverage-test-report.xml\" && dotnet test -f netcoreapp3.1 ./test/Appium --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
     "dotnet:report": "[ \"$TEST_REPORT_SANDBOX\" = \"False\" ] && npm run dotnet:report:prod || npm run dotnet:report:sandbox ",
-    "dotnet:report:sandbox": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Appium",
+    "dotnet:report:sandbox": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Appium",
     "dotnet:report:prod": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium",
     "dotnet:tests": "./dotNet/dotnet_tests.sh"
   },

--- a/coverage-tests/package.json
+++ b/coverage-tests/package.json
@@ -19,14 +19,14 @@
     "dotnet:generate:win": "npm install && coverage-tests generate ./configuration --pascalizeTests --strict && move /Y .\\test\\Selenium\\coverage\\generic\\*Native*.cs .\\test\\Appium\\coverage\\generic && move /Y .\\test\\Selenium\\coverage\\generic\\Appium*.cs .\\test\\Appium\\coverage\\generic",
     "dotnet:generate:win:local": "coverage-tests generate ./configuration --pascalizeTests --strict --tests ./coverage-tests.js && move /Y .\\test\\Selenium\\coverage\\generic\\*Native*.cs .\\test\\Appium\\coverage\\generic && move /Y .\\test\\Selenium\\coverage\\generic\\Appium*.cs .\\test\\Appium\\coverage\\generic",
     "dotnet:run:parallelOld": "cd .. && dotnet test -f netcoreapp3.1 Eyes.Sdk.DotNet_Travis.sln --filter Generated --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
-	"dotnet:run:parallel": "dotnet test -f netcoreapp3.1 ./test/Selenium --logger \"junit;LogFilePath=./coverage-test-report.xml\" && dotnet test -f netcoreapp3.1 ./test/Appium --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
+    "dotnet:run:parallel": "dotnet test -f netcoreapp3.1 ./test/Selenium --logger \"junit;LogFilePath=./coverage-test-report.xml\" && dotnet test -f netcoreapp3.1 ./test/Appium --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
     "dotnet:report": "[ \"$TEST_REPORT_SANDBOX\" = \"False\" ] && npm run dotnet:report:prod || npm run dotnet:report:sandbox ",
     "dotnet:report:sandbox": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Appium",
     "dotnet:report:prod": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium",
     "dotnet:tests": "./dotNet/dotnet_tests.sh"
   },
   "dependencies": {
-    "@applitools/sdk-coverage-tests": "^2.3.0",
+    "@applitools/sdk-coverage-tests": "^2.3.7",
     "@typescript-eslint/parser": "^2.14.0",
     "typescript": "^3.7.4"
   },

--- a/coverage-tests/package.json
+++ b/coverage-tests/package.json
@@ -21,7 +21,7 @@
     "dotnet:run:parallelOld": "cd .. && dotnet test -f netcoreapp3.1 Eyes.Sdk.DotNet_Travis.sln --filter Generated --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
     "dotnet:run:parallel": "dotnet test -f netcoreapp3.1 ./test/Selenium --logger \"junit;LogFilePath=./coverage-test-report.xml\" && dotnet test -f netcoreapp3.1 ./test/Appium --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
     "dotnet:report": "[ \"$TEST_REPORT_SANDBOX\" = \"False\" ] && npm run dotnet:report:prod || npm run dotnet:report:sandbox ",
-    "dotnet:report:sandbox": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Appium",
+    "dotnet:report:sandbox": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Appium",
     "dotnet:report:prod": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium",
     "dotnet:tests": "./dotNet/dotnet_tests.sh"
   },

--- a/coverage-tests/package.json
+++ b/coverage-tests/package.json
@@ -18,7 +18,7 @@
     "dotnet:generate:local": "npm install && coverage-tests generate ./configuration --pascalizeTests --strict --tests ./coverage-tests.js && mv ./test/Selenium/coverage/generic/*Native*.cs ./test/Appium/coverage/generic && mv ./test/Selenium/coverage/generic/Appium*.cs ./test/Appium/coverage/generic",
     "dotnet:generate:win": "npm install && coverage-tests generate ./configuration --pascalizeTests --strict && move /Y .\\test\\Selenium\\coverage\\generic\\*Native*.cs .\\test\\Appium\\coverage\\generic && move /Y .\\test\\Selenium\\coverage\\generic\\Appium*.cs .\\test\\Appium\\coverage\\generic",
     "dotnet:generate:win:local": "coverage-tests generate ./configuration --pascalizeTests --strict --tests ./coverage-tests.js && move /Y .\\test\\Selenium\\coverage\\generic\\*Native*.cs .\\test\\Appium\\coverage\\generic && move /Y .\\test\\Selenium\\coverage\\generic\\Appium*.cs .\\test\\Appium\\coverage\\generic",
-    "dotnet:run:parallel": "APPLITOOLS_BATCH_ID=$(uuidgen) dotnet test --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
+    "dotnet:run:parallel": "cd .. && APPLITOOLS_BATCH_ID=$(uuidgen) dotnet test -f netcoreapp3.1 Eyes.Sdk.DotNet_Travis.sln --filter Generated --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
     "dotnet:report": "[ \"$TEST_REPORT_SANDBOX\" = \"False\" ] && npm run dotnet:report:prod || npm run dotnet:report:sandbox ",
     "dotnet:report:sandbox": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID",
     "dotnet:report:prod": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID",

--- a/coverage-tests/package.json
+++ b/coverage-tests/package.json
@@ -21,11 +21,10 @@
     "dotnet:run:parallelOld": "cd .. && dotnet test -f netcoreapp3.1 Eyes.Sdk.DotNet_Travis.sln --filter Generated --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
     "dotnet:run:parallel:selenium": "dotnet test -f netcoreapp3.1 ./test/Selenium --logger \"junit;LogFilePath=./../coverage-test-reportS.xml\"",
 	"dotnet:run:parallel:appium": "dotnet test -f netcoreapp3.1 ./test/Appium --logger \"junit;LogFilePath=./../coverage-test-reportA.xml\"",
-    "dotnet:run:parallel22": "dotnet test -f netcoreapp3.1 ./test --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
     "dotnet:report:merge": "junit-merge -d test -o coverage-test-report.xml",
     "dotnet:report": "[ \"$TEST_REPORT_SANDBOX\" = \"False\" ] && npm run dotnet:report:prod || npm run dotnet:report:sandbox ",
     "dotnet:report:sandboxOLD": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Appium",
-    "dotnet:report:sandbox": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID && coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID",
+    "dotnet:report:sandbox": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID",
     "dotnet:report:prodOLD": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium",
     "dotnet:report:prod": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID",
     "dotnet:tests": "./dotNet/dotnet_tests.sh"

--- a/coverage-tests/package.json
+++ b/coverage-tests/package.json
@@ -21,7 +21,7 @@
     "dotnet:run:parallelOld": "cd .. && dotnet test -f netcoreapp3.1 Eyes.Sdk.DotNet_Travis.sln --filter Generated --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
     "dotnet:run:parallel": "dotnet test -f netcoreapp3.1 ./test/Selenium --logger \"junit;LogFilePath=./coverage-test-report.xml\" && dotnet test -f netcoreapp3.1 ./test/Appium --logger \"junit;LogFilePath=./coverage-test-report.xml\"",
     "dotnet:report": "[ \"$TEST_REPORT_SANDBOX\" = \"False\" ] && npm run dotnet:report:prod || npm run dotnet:report:sandbox ",
-    "dotnet:report:sandbox": "coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --sandbox --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Appium",
+    "dotnet:report:sandbox": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Appium",
     "dotnet:report:prod": "coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium && coverage-tests report ./configuration --reportId $APPLITOOLS_REPORT_ID --resultDir ./test/Selenium",
     "dotnet:tests": "./dotNet/dotnet_tests.sh"
   },

--- a/coverage-tests/test/Appium/TestSetupGeneratedAppium.cs
+++ b/coverage-tests/test/Appium/TestSetupGeneratedAppium.cs
@@ -12,7 +12,7 @@ using Applitools.Tests.Utils;
 
 namespace Applitools.Generated.Appium.Tests
 {
-	public abstract class TestSetupGeneratedAppium
+	public abstract class TestSetupGeneratedAppium// : ReportingTestSuiteGenerratedAppium
 	{
 
 		protected RemoteWebDriver driver;

--- a/coverage-tests/test/Appium/TestSetupGeneratedAppium.cs
+++ b/coverage-tests/test/Appium/TestSetupGeneratedAppium.cs
@@ -12,7 +12,7 @@ using Applitools.Tests.Utils;
 
 namespace Applitools.Generated.Appium.Tests
 {
-	public abstract class TestSetupGeneratedAppium : ReportingTestSuiteGenerratedAppium
+	public abstract class TestSetupGeneratedAppium
 	{
 
 		protected RemoteWebDriver driver;

--- a/coverage-tests/test/Appium/Tests.Eyes.Appium.Generated.csproj
+++ b/coverage-tests/test/Appium/Tests.Eyes.Appium.Generated.csproj
@@ -16,7 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>

--- a/coverage-tests/test/Selenium/TestSetupGenerated.cs
+++ b/coverage-tests/test/Selenium/TestSetupGenerated.cs
@@ -17,7 +17,7 @@ using System.Threading;
 
 namespace Applitools.Generated.Selenium.Tests
 {
-    public abstract class TestSetupGenerated
+    public abstract class TestSetupGenerated// : ReportingTestSuiteGenerrated
     {
 
         protected IWebDriver driver;

--- a/coverage-tests/test/Selenium/TestSetupGenerated.cs
+++ b/coverage-tests/test/Selenium/TestSetupGenerated.cs
@@ -17,7 +17,7 @@ using System.Threading;
 
 namespace Applitools.Generated.Selenium.Tests
 {
-    public abstract class TestSetupGenerated : ReportingTestSuiteGenerrated
+    public abstract class TestSetupGenerated
     {
 
         protected IWebDriver driver;

--- a/coverage-tests/test/Selenium/Tests.Eyes.Selenium.Generated.csproj
+++ b/coverage-tests/test/Selenium/Tests.Eyes.Selenium.Generated.csproj
@@ -16,7 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>

--- a/genericTests.sh
+++ b/genericTests.sh
@@ -15,18 +15,42 @@ if [ $? -ne 0 ]; then
 fi
 popd
 
-echo "running tests"
+echo "running tests selenium"
 pushd coverage-tests
-npm run dotnet:run:parallel
+npm run dotnet:run:parallel:selenium
 result=$?
 echo $result
 if [ $result -ne 0 ]; then
     echo "Not all tests passed... Retrying."
-    npm run dotnet:run:parallel
+    npm run dotnet:run:parallel:selenium
 	if [ $? -ne 0 ]; then
       RESULT=1
-      echo "npm run dotnet:run:parallel have failed"
+      echo "npm run dotnet:run:parallel:selenium have failed"
     fi
+fi
+popd
+
+echo "running tests appium"
+pushd coverage-tests
+npm run dotnet:run:parallel:appium
+result=$?
+echo $result
+if [ $result -ne 0 ]; then
+    echo "Not all tests passed... Retrying."
+    npm run dotnet:run:parallel:appium
+	if [ $? -ne 0 ]; then
+      RESULT=1
+      echo "npm run dotnet:run:parallel:appium have failed"
+    fi
+fi
+popd
+
+echo "merge reports"
+pushd coverage-tests
+npm run dotnet:report:merge
+if [ $? -ne 0 ]; then
+    RESULT=1
+    echo "npm run dotnet:report:merge have failed"
 fi
 popd
 

--- a/genericTests.sh
+++ b/genericTests.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+pushd Eyes.Selenium.DotNet/Properties/NodeResources
+npm install
+popd
+
+RESULT=0
+
+echo "generating tests"
+pushd coverage-tests
+npm run dotnet:generate
+if [ $? -ne 0 ]; then
+    RESULT=1
+    echo "npm run dotnet:generate have failed"
+fi
+popd
+
+echo "running tests"
+pushd coverage-tests
+npm run dotnet:run:parallel
+result=$?
+echo $result
+if [ $result -ne 0 ]; then
+    echo "Not all tests passed... Retrying."
+    npm run dotnet:run:parallel
+	if [ $? -ne 0 ]; then
+      RESULT=1
+      echo "npm run dotnet:run:parallel have failed"
+    fi
+fi
+popd
+
+echo "tests reporting"
+pushd coverage-tests
+npm run dotnet:report
+if [ $? -ne 0 ]; then
+    RESULT=1
+    echo "npm run dotnet:report have failed"
+fi
+popd
+
+echo "RESULT = ${RESULT}"
+if [ $RESULT -eq 0 ]; then
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
By this PR  run and reporting of generic tests will switch under the control of sdk.coverage.tests framework. It need to perform reporting according to last updates in the framework. Also future framework's updates will be automaticly implemented for DotNet generic tests